### PR TITLE
Fixes data_subset generation for the case of partial video dataset download

### DIFF
--- a/scripts/generate_data_subset.py
+++ b/scripts/generate_data_subset.py
@@ -2,6 +2,7 @@
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from shutil import copyfile, move
+import os
 
 import numpy as np
 import pandas as pd
@@ -46,9 +47,15 @@ def main(args: Namespace):
 
     p_subset = args.subset_proportion
 
+    # Get a list of actually downloaded videos in system
+    video_ids = os.listdir(query_video_dir)
+    video_ids = [elem.replace('.mp4', '') for elem in video_ids]
+    
+    query_metadata_df = pd.read_csv(query_metadata)
+    # Filter out the listed video_ids that are not in the system
+    query_metadata_df = query_metadata_df[query_metadata_df['video_id'].isin(video_ids)]
     # Choose a random subset of query IDs to include
     rng = np.random.RandomState(42)
-    query_metadata_df = pd.read_csv(query_metadata)
     subset_query_ids = query_metadata_df.video_id.sample(
         int(np.ceil(query_metadata_df.shape[0] * p_subset)), random_state=rng
     )


### PR DESCRIPTION
When following quickstart instructions, the possibility of retrieving a smaller subset of videos is opened in the [data download page](https://www.drivendata.org/competitions/101/meta-video-similarity-descriptor/data/).

This is a very good option in order to get started.

However, the generate_data_subset script deals poorly with that situation as it assumes the whole list of video_ids from the .csv must be present.

This PR aims at fixing that by filtering out the Pandas dataframe entries with the existing .mp4 list found in the queries directory.