### PR TITLE
Add some pinned deps to runtime envs

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - av=9.2.0
   - cpuonly=2.0
   - cython=0.29.32
   - faiss-cpu=1.7.2
@@ -34,5 +35,10 @@ dependencies:
   - tslearn=0.5.2
   - pip: 
     - augly[image,video]==1.0.0
+    - decord==0.6.0
     - lightning-flash[video,image]==0.8.1
+    - pytorch-lightning==1.8.6
+    - pytorchvideo==0.1.5
     - tensorflow-cpu==2.9.1
+    - timm==0.6.12
+    - transformers==4.25.1

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -39,6 +39,7 @@ dependencies:
     - lightning-flash[video,image]==0.8.1
     - pytorch-lightning==1.8.6
     - pytorchvideo==0.1.2
+    - segmentation-models-pytorch==0.3.2
     - tensorflow-cpu==2.9.1
     - timm==0.6.12
     - transformers==4.25.1

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -38,7 +38,7 @@ dependencies:
     - decord==0.6.0
     - lightning-flash[video,image]==0.8.1
     - pytorch-lightning==1.8.6
-    - pytorchvideo==0.1.5
+    - pytorchvideo==0.1.2
     - tensorflow-cpu==2.9.1
     - timm==0.6.12
     - transformers==4.25.1

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - av=9.2.0
   - cudnn=8.2.1.32
   - cython=0.29.32
   - faiss-gpu=1.7.2
@@ -36,4 +37,8 @@ dependencies:
   - pip: 
     - augly[image,video]==1.0.0
     - lightning-flash[video,image]==0.8.1
+    - pytorch-lightning==1.8.6
+    - pytorchvideo==0.1.5
     - tensorflow-gpu==2.9.1
+    - timm==0.6.12
+    - transformers==4.25.1

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -38,7 +38,7 @@ dependencies:
     - augly[image,video]==1.0.0
     - lightning-flash[video,image]==0.8.1
     - pytorch-lightning==1.8.6
-    - pytorchvideo==0.1.5
+    - pytorchvideo==0.1.2
     - tensorflow-gpu==2.9.1
     - timm==0.6.12
     - transformers==4.25.1

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -39,6 +39,7 @@ dependencies:
     - lightning-flash[video,image]==0.8.1
     - pytorch-lightning==1.8.6
     - pytorchvideo==0.1.2
+    - segmentation-models-pytorch==0.3.2
     - tensorflow-gpu==2.9.1
     - timm==0.6.12
     - transformers==4.25.1


### PR DESCRIPTION
Here I'm adding a few helpful deps for videos...

- `decord` a fast video decoder. probably very helpful for folks to make submissions faster.
- `pytorchvideo` - facebookresearch library containing a bunch of helpful video utilities
- `av` helpful reader/writer (used by pytorchvideo). Is a little slower than decord but has more features/I've found it to be a bit more stable in my experience

...as well as adding:
- `timm`, which has a bunch of pretrained vision models folks may want to leverage
- `transformers`, which has vision models as well (notably some nice video models I was playing with)

I also pinned the version of `pytorch-lightning` because lightning flash had a loose version of it in its requirements.

I didn't build this on CPU or GPU...I read there were GH actions so I'm hoping I can just work against that 😉 

Happy to discuss if you folks don't want some of these in the environment!