### PR TITLE
Fix fast exit

### DIFF
--- a/runtime/entrypoint.sh
+++ b/runtime/entrypoint.sh
@@ -26,7 +26,7 @@ exit_code=0
             --ref_metadata /data/reference_metadata.csv
     else
         echo "ERROR: Could not find query_descriptors.npz or reference_descriptors.npz in submission.zip"
-        exit_code=1
+        exit 1
     fi
 
     # Use submitted code to generate descriptors on a subset of query videos


### PR DESCRIPTION
This PR causes the entrypoint script to exit quickly if the required descriptor npz files are not present.

Closes #35 