### PR TITLE
Add imageio[ffmpeg]

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -36,6 +36,7 @@ dependencies:
   - pip: 
     - augly[image,video]==1.0.0
     - decord==0.6.0
+    - imageio[ffmpeg]==2.25.0
     - lightning-flash[video,image]==0.8.1
     - pytorch-lightning==1.8.6
     - pytorchvideo==0.1.2

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -36,6 +36,7 @@ dependencies:
   - tslearn=0.5.2
   - pip: 
     - augly[image,video]==1.0.0
+    - imageio[ffmpeg]==2.25.0
     - lightning-flash[video,image]==0.8.1
     - pytorch-lightning==1.8.6
     - pytorchvideo==0.1.2


### PR DESCRIPTION
This PR updates the `imageio` package installed as a dependency of a conda package to the pip-installed version with an `ffmpeg` backend.