### PR TITLE
Add start and finish timestamp logs to runtime

### DIFF
--- a/runtime/entrypoint.sh
+++ b/runtime/entrypoint.sh
@@ -33,11 +33,11 @@ exit_code=0
     if [ -f "main.py" ]
     then
         echo "Generating descriptors on a subset of query videos..."
-        echo "Started at $(date +%s)"
+        echo "Started at $(date -u +'%Y-%m-%dT%H:%M:%SZ') ($(date +%s))"
 
         conda run --no-capture-output -n condaenv python main.py
 
-        echo "Finished at $(date +%s)
+        echo "Finished at $(date -u +'%Y-%m-%dT%H:%M:%SZ') ($(date +%s))"
 
         # If code successfully generates subset of descriptors, run similarity search
         # to generate similarity rankings

--- a/runtime/entrypoint.sh
+++ b/runtime/entrypoint.sh
@@ -33,8 +33,11 @@ exit_code=0
     if [ -f "main.py" ]
     then
         echo "Generating descriptors on a subset of query videos..."
+        echo "Started at $(date +%s)"
 
         conda run --no-capture-output -n condaenv python main.py
+
+        echo "Finished at $(date +%s)
 
         # If code successfully generates subset of descriptors, run similarity search
         # to generate similarity rankings


### PR DESCRIPTION
This PR adds logging in `entrypoint.sh` to provide feedback around the amount of inference time taken by logging the start and end times of `main.py`.